### PR TITLE
Add nilcheck for DSN mapping

### DIFF
--- a/sentry-gateway.go
+++ b/sentry-gateway.go
@@ -257,8 +257,9 @@ func run(cmd *cobra.Command, args []string) error {
 			}
 
 			if projectLabel := alert.Labels["sentry_project"]; projectLabel != "" {
-				if newDSN := projectLabelToDSN[projectLabel].(string); newDSN != "" {
-					dsn = newDSN
+				newDSN := projectLabelToDSN[projectLabel]
+				if newDSN != nil && newDSN.(string) != "" {
+					dsn = newDSN.(string)
 				}
 			}
 			hookChan <- gatewayRequest{dsn, alert_env, alert}


### PR DESCRIPTION
Forgot to test that the feature to use the default DSN when no sentry_project label is present or its value is not in the file passed as `--project-label-mapping` actually worked, and it doesn't:

```
2024/12/19 13:52:11 http: panic serving 127.0.0.1:59438: interface conversion: interface {} is nil, not string
goroutine 23 [running]:
net/http.(*conn).serve.func1()
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/net/http/server.go:1947 +0xbe
panic({0x898820?, 0xc00025d710?})
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/runtime/panic.go:785 +0x132
main.run.func1({0x0?, 0xc0000a1b40?}, 0xc00034c000)
        /home/maarten/channable/alertmanager-sentry-gateway/sentry-gateway.go:250 +0xb8e
net/http.HandlerFunc.ServeHTTP(0xc00033c098?, {0xa82620?, 0xc00033c0e0?}, 0x0?)
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/net/http/server.go:2220 +0x29
net/http.(*ServeMux).ServeHTTP(0x411ea5?, {0xa82620, 0xc00033c0e0}, 0xc00034c000)
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/net/http/server.go:2747 +0x1ca
net/http.serverHandler.ServeHTTP({0xa80bc8?}, {0xa82620?, 0xc00033c0e0?}, 0x6?)
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc00033a120, {0xa837b8, 0xc000116270})
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 19
        /nix/store/zhq8dnjbhwspzdglyq28j74axvqyk86q-go-1.23.3/share/go/src/net/http/server.go:3360 +0x485
```

This PR adds a nil check so this does hopefully not happen (tested locally and works).